### PR TITLE
Transparent mode, default csurl and request error management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # proxy.php
 A Single-File PHP-based proxy that just works - supports all HTTP verbs and file uploads as well!
 
-History:
-========
+## History
 
 This proxy was inspired by and originally built around the proxy [here](https://code.google.com/p/php-proxy/). 
 I went ahead and extended that proxy to allow file uploads as well, and to auto set `application/json` as a fallback content-type
 where it is not specified by the client (motivation being, I was specifically using this proxy for API proxying).
 
-HOW-TO:
-=======
+## HOW-TO
 
-Send request to your script and set query parametr `csurl` to desired URL with its schema.
+It is possible to use the proxy with two modes:
+
+### Non-transparent mode:
+
+Send request to your script and set query parameter `csurl` to desired URL with its schema.
 
 Example:
 
@@ -23,7 +25,36 @@ Also you can use cURL for test in this way:
 
 Where `proxy.xyz.com` - your domain name.
 
-INSTALL
+### Transparent mode:
+
+In this case the `csurl` query parameter does not contain the entire schema, but only the destination domain. The schema, instead, is in the proxy url.
+
+Example:
+
+`https://proxy.xyz.com/proxy.php/notifications?csurl=https://github.com`
+
+performs a request to
+
+`https://github.com/notifications`
+
+---
+
+**NOTE**: If set to true SETTING_PROXY_PATH in config file should be configured with the proxy path. In the previous example the SETTING_PROXY_PATH constant should be set as `SETTING_PROXY_PATH = "/proxy.php"`
+
+---
+
+It might also be possible to omit the `csurl` query parameter in all the requests by setting a default value in the config file. For example, with the transparent mode enabled, by setting `SETTING_CSURL_DEFAULT = "https://github.com"`:
+
+`https://proxy.xyz.com/proxy.php/notifications`
+
+performs a request to
+
+`https://github.com/notifications`
+
+In any case, it is stil possible to explicit the `csurl` in the query parameter, whose value overrides the default one.
+
+
+## INSTALL
 
 1. Preferably use the proxy on it's own domain e.g. http://proxy.xyz.com/
    

--- a/config.php
+++ b/config.php
@@ -1,9 +1,21 @@
 <?php
 
-/*
+/**
  * Place here any hosts for which we are to be a proxy -
  * e.g. the host on which the J2EE APIs we'll be proxying are running
- * */
+ */
 $SETTING_ALLOWED_HOSTS = array(
     'localhost','127.0.0.1', 'httpbin.org' # change to restrict list to only domains you wish to allow clients to call via this proxy
 );
+
+/**
+* Default csurl value, to be used if not explictly passed
+* this option allow to omit the csurl in the query of every request
+*/
+# $SETTING_CSURL_DEFAULT = "http://destination.com";
+
+/**
+* Url of the proxy, needed if the proxy is used in transparent mode
+* Uncomment and change with the current proxy path when the transparent mode is enabled
+*/
+# $SETTING_PROXY_PATH = "/proxy/proxy.php";

--- a/proxy.php
+++ b/proxy.php
@@ -105,7 +105,7 @@ if ( 'GET' == $request_method ) {
 }
 
 // Get URL from `csurl` in GET or POST data, before falling back to X-Proxy-URL header.
-// If none of the have `csurl` use default value if set
+// If none of them have `csurl`, use default value if set
 if ( isset( $_REQUEST['csurl'] ) ) {
     $request_url = urldecode( $_REQUEST['csurl'] );
 } else if ( isset( $_SERVER['HTTP_X_PROXY_URL'] ) ) {


### PR DESCRIPTION
This pull request provides the following modifications:

**New functionalities**

- The **default csurl** allows to omit the csurl in all the requests. This means that if the csurl is not explicitly declared in the request, the default one is used.
- **Transparent mode**: by enabling the transparent mode, it is not needed to specify the entire url schema in the csurl field, but in the proxy url.

For example:

If default csurl is NOT enabled:

`http://yourdomain.com/proxy/api/tasks?csurl=https://destination.com --(becomes)--> https://destination.com/api/tasks`

If default csurl is set to `https://destination.com`: 

`http://yourdomain.com/proxy/api/tasks? --(becomes)--> https://destination.com/api/tasks`

**Issue fix**

With the previous version of the code the case in which the php curl_exec() fails is not handled. In this case, whenever the request fails a 500 error is reported.